### PR TITLE
Fix firebase library link

### DIFF
--- a/Resources/config.xml
+++ b/Resources/config.xml
@@ -5,7 +5,7 @@
         <element type="textarea">
             <name>firebaseConfiguration</name>
             <label>Firebase Setup Code</label>
-            <value><![CDATA[<script src="https://www.gstatic.com/firebasejs/5.0.4/firebase.min.js"></script>
+            <value><![CDATA[<script src="https://www.gstatic.com/firebasejs/5.0.4/firebase.js"></script>
 <script>
   // Initialize Firebase
   var config = {


### PR DESCRIPTION
https://www.gstatic.com/firebasejs/5.0.4/firebase.min.js points to a 404. 
Instead the minified version will be delivered without the .min part in the url.